### PR TITLE
Latest News, Next Projects, Multiple Authors etc

### DIFF
--- a/components/latestNews.js
+++ b/components/latestNews.js
@@ -22,7 +22,7 @@ const styles = theme => ({
 
 function LatestNews(props) {
   const { classes } = props;
-
+  
     return (
       <div className={classes.root}>
 
@@ -44,49 +44,45 @@ function LatestNews(props) {
         <Grid item xs={1} sm={1} md={1} lg={1}></Grid>
         <Grid item xs={10} sm={11} md={11} lg={10}>
         <Grid container spacing={40}>
-          <Grid item xs={12} sm={3} md={3} lg={3} className="latestNews">
-            <Typography variant='title' gutterBottom>
-              Product Relays™
-            </Typography>
-            <br></br>
-            <Typography variant='body1' gutterBottom>
-            Product Relays are a framework that combines Design Sprints with a Modified Agile Sprints helping teams collaborate and work more efficiently together.
-            </Typography>
-            <Button style={{paddingTop:'10px'}} disableRipple={true} className={"underline"} href="/work">
-              <Typography variant="button" color="inherit">
-                Read more <Icon style={{fontSize:'14px', verticalAlign: 'middle',}}>chevron_right</Icon>
+        {props.news.map((latestNews) => {
+          return(
+            <Grid item xs={12} sm={3} md={3} lg={3} className="latestNews">
+              <Typography variant='title' gutterBottom>
+                {latestNews.acf.headline}
               </Typography>
-            </Button>
-          </Grid>
-          <Grid item xs={12} sm={3} md={3} lg={3} className="latestNews">
-            <Typography variant='title' gutterBottom>
-              Product Relays™
-            </Typography>
-            <br></br>
-            <Typography variant='body1' gutterBottom>
-            Product Relays are a framework that combines Design Sprints with a Modified Agile Sprints helping teams collaborate and work more efficiently together.
-            </Typography>
-            <Button style={{paddingTop:'10px'}} disableRipple={true} className={"underline"} href="/work">
-              <Typography variant="button" color="inherit">
-                Read more <Icon style={{fontSize:'14px', verticalAlign: 'middle',}}>chevron_right</Icon>
+              <br></br>
+              <Typography variant='body1' gutterBottom>
+              {latestNews.acf.short_description}
               </Typography>
-            </Button>
-          </Grid>
-          <Grid item xs={12} sm={3} md={3} lg={3} className="latestNews">
-            <Typography variant='title' gutterBottom>
-              Product Relays™
-            </Typography>
-            <br></br>
-            <Typography variant='body1' gutterBottom>
-            Product Relays are a framework that combines Design Sprints with a Modified Agile Sprints helping teams collaborate and work more efficiently together.
-            </Typography>
-            <Button style={{paddingTop:'10px'}} disableRipple={true} className={"underline"} href="/work">
-              <Typography variant="button" color="inherit">
-                Read more <Icon style={{fontSize:'14px', verticalAlign: 'middle',}}>chevron_right</Icon>
+              <Button style={{paddingTop:'10px'}} disableRipple={true} className={"underline"} href={latestNews.acf.link}>
+                <Typography variant="button" color="inherit">
+                  Read more <Icon style={{fontSize:'14px', verticalAlign: 'middle',}}>chevron_right</Icon>
+                </Typography>
+              </Button>
+            </Grid>
+          )
+        })}
+
+        {props.blogs.map((latestNews) => {
+          return(
+            <Grid item xs={12} sm={3} md={3} lg={3} className="latestNews">
+              <Typography variant='title' gutterBottom>
+                {latestNews.acf.title}
               </Typography>
-            </Button>
-            <Hidden smUp><Divider style={{marginTop:'40px'}} /></Hidden>
-          </Grid>
+              <br></br>
+              <Typography variant='body1' gutterBottom noWrap={true}>
+              {latestNews.acf.short_description}
+              </Typography>
+              <Button style={{paddingTop:'10px'}} disableRipple={true} className={"underline"} href={`post?${latestNews.slug}`}>
+                <Typography variant="button" color="inherit">
+                  Read more <Icon style={{fontSize:'14px', verticalAlign: 'middle',}}>chevron_right</Icon>
+                </Typography>
+              </Button>
+            </Grid>
+          )
+        })}
+          
+
           <Grid item xs={12} sm={12} md={2} lg={3} style={{display: 'flex', alignItems:'center'}}>
 
             <Button style={{paddingTop:'10px'}} disableRipple={true} className={"underline"} href="/blog">

--- a/components/ourWorkshops.js
+++ b/components/ourWorkshops.js
@@ -47,7 +47,9 @@ const imgContainer = {
 }
 
 const imgStyle = {
-  maxWidth:'370px',
+  backgroundSize: 'cover',
+  width:'100%',
+  maxWidth: '375px',
   margin: '0 auto',
   height: 'auto',
 }
@@ -82,9 +84,16 @@ function OurWorkshops(props) {
           <Grid item xs={10} sm={7}>
             <Grid container>
               <Grid item xs={10} sm={10} md={6} style={imgContainer}>
-                <img src='https://cdn1.academyux.com/workshop5.jpg'
-                  style={imgStyle}
-                />
+                <div 
+                  style={{
+                    background: 'url(https://cdn1.academyux.com/workshop5.jpg) center',
+                    backgroundSize: 'cover',
+                    width:'100%',
+                    maxWidth: '375px',
+                    margin: '0 auto',
+                    height: 'auto',
+                  }}
+                ></div>
                
               </Grid>
               <Grid item xs={1} sm={1} md={1}></Grid>
@@ -104,9 +113,16 @@ function OurWorkshops(props) {
             </Grid>
             <Grid container>
               <Grid item xs={10} sm={10} md={6} style={imgContainer}>
-                <img src='https://cdn1.academyux.com/workshop9.jpg'
-                  style={imgStyle}
-                />
+                <div 
+                  style={{
+                    background: 'url(https://cdn1.academyux.com/workshop9.jpg) center',
+                    backgroundSize: 'cover',
+                    width:'100%',
+                    maxWidth: '375px',
+                    margin: '0 auto',
+                    height: 'auto',
+                  }}
+                ></div>
               </Grid>
               <Grid item xs={1} sm={1} md={1}></Grid>
               <Grid item xs={10} sm={10} md={4}>
@@ -126,9 +142,16 @@ function OurWorkshops(props) {
             <Grid container>
 
               <Grid item xs={10} sm={10} md={6} style={imgContainer}>
-                <img src='https://cdn1.academyux.com/workshop1.jpg'
-                  style={imgStyle}
-                />
+                <div 
+                  style={{
+                    background: 'url(https://cdn1.academyux.com/workshop1.jpg) center',
+                    backgroundSize: 'cover',
+                    width:'100%',
+                    maxWidth: '375px',
+                    margin: '0 auto',
+                    height: 'auto',
+                  }}
+                ></div>
               </Grid>
               <Grid item xs={1} sm={1} md={1}></Grid>
               <Grid item xs={10} sm={10} md={4}>

--- a/pages/blog.js
+++ b/pages/blog.js
@@ -68,6 +68,7 @@ class Blog extends React.Component {
       loaded: false,
     };
     this.handleScroll = this.handleScroll.bind(this);
+    
   }
 
   componentDidMount() {
@@ -149,6 +150,8 @@ class Blog extends React.Component {
     })
   }
 
+  
+
   formatDate = (date) =>{
     let format = new Date(date);
     format = format.toDateString();
@@ -156,9 +159,17 @@ class Blog extends React.Component {
     return format;
   }
 
+  getAuthors = (authors) => {
+    let res = []
+    authors.map((author) => {
+      res.push(author.display_name)
+    })
+    return res.join(", ")
+  }
+
   render() {
     const { classes } = this.props;
-    const isBrowser = typeof window !== "undefined";
+    
      return (
       <div className={classes.root}>
         <Head>
@@ -243,7 +254,20 @@ class Blog extends React.Component {
                     {this.formatDate(this.props.featuredBlog[0].date)}
                     </Typography>
                     <Typography variant="caption" gutterBottom>
-                      By {this.props.featuredBlog[0].acf.author.display_name}
+                      <Grid container>
+                       {this.props.featuredBlog[0].acf.author.map((authors) => {
+                        return(
+                          
+                          <Grid item xs={6} md={6} style={{display:'flex', alignItems:'center'}}>
+                          <div className="author-profile"   dangerouslySetInnerHTML={{__html: authors.user_avatar}}></div>
+                          <div style={{display: 'inline-block', paddingLeft: '15px'}}>
+                          <Typography variant="button">by {authors.display_name}</Typography>
+                          <Typography variant="caption"><span dangerouslySetInnerHTML={{__html:authors.user_description}}></span></Typography>
+                          </div>
+                        </Grid>
+                        )
+                      })}
+                      </Grid>
                     </Typography>
                   </Paper>
                   </Grid>
@@ -269,7 +293,6 @@ class Blog extends React.Component {
                   return (
                     <Link key={blog.id} href={{ pathname: 'post', query: { name: blog.slug }}} as={`/post?${blog.slug}`}>
                     <Grid item xs={12} sm={8} md={4} className="heroHover" style={{paddingTop:'50px'}}  value={blog} >
-                    
                           <img src={blog.acf.featured_image}
                             style={{
                                 height: '20vh',
@@ -278,7 +301,6 @@ class Blog extends React.Component {
                             }}
                             alt="featured Image"
                           />
-
                           <Paper elevation={0} style={{padding:'30px', textAlign:'center'}} className="headlineHover">
                             <Typography variant="headline" paragraph>
                             {blog.acf.title}
@@ -287,10 +309,9 @@ class Blog extends React.Component {
                               {this.formatDate(blog.date)}
                             </Typography>
                             <Typography variant="caption" gutterBottom>
-                              By {blog.acf.author.display_name}
+                              By {this.getAuthors(blog.acf.author)}
                             </Typography>
                           </Paper>
-                        
                     </Grid>
                     </Link>
                   )

--- a/pages/index.js
+++ b/pages/index.js
@@ -11,15 +11,49 @@ import OurProcess from '../components/ourProcess'
 import OurWorkshops from '../components/ourWorkshops'
 import LatestNews from '../components/latestNews'
 import Carousel from '../components/carousel'
+const fetchUrl = process.env.fetchUrl
+import 'isomorphic-fetch'
 
 const styles = theme => ({
   root: {
     flexGrow: 1
   }
 });
+class Index extends React.Component {
 
-function Index(props) {
-  const { classes } = props;
+  constructor(props) {
+    super(props);
+    
+    this.state = {
+      /* initial state */ 
+    };
+  }
+
+  static async getInitialProps(nextProps){
+    const url = "https://" + fetchUrl + "/wp-json/wp/v2/news?per_page=3";
+    const res = await fetch(url);
+    const news = await res.json();
+    if (news.length == 3){
+      return {
+        news: news,
+      }
+    }
+    else{
+      const count = 3 - news.length;
+      const blogUrl = "https://" + fetchUrl + "/wp-json/wp/v2/blogs?per_page=" + count;
+      const blogRes = await fetch(blogUrl);
+      const blogs = await blogRes.json();
+      return{
+        news: news,
+        blogs: blogs,
+      }
+    }
+  }
+
+  render() {
+
+  const { classes } = this.props;
+
   return (
     <div className={classes.root}>
 
@@ -33,11 +67,12 @@ function Index(props) {
 
           <OurWorkshops />
 
-          <LatestNews />
+          <LatestNews blogs={this.props.blogs} news={this.props.news}/>
 
     </div>
     );
   }
+}
 
 Index.propTypes = {
   classes: PropTypes.object.isRequired,

--- a/pages/post.js
+++ b/pages/post.js
@@ -13,6 +13,7 @@ import Divider from 'material-ui/Divider';
 import Paper from 'material-ui/Paper';
 import "../styles.scss"
 import Head from 'next/head'
+import Chip from 'material-ui/Chip'
 
 
 
@@ -27,7 +28,7 @@ class Post extends React.Component {
 
   constructor(children, router, href) {
     super(children, router, href);
-    //console.log(props);
+    
     this.state = {
       /* initial state */
       fetching: true,
@@ -57,48 +58,41 @@ class Post extends React.Component {
     return format;
   }
 
+  getAuthors = (authors) => {
+    let res = []
+    authors.map((author) => {
+      res.push(author.display_name)
+    })
+    return res.join(", ")
+  }
+
   //fetch details of the blog here
   static async getInitialProps(nextProps) {
     
     //To share the post use the following plugin
     //console.log(window.location.href);
-    //console.log(this.state.children);
+    
     let path = nextProps.asPath
-    //console.log(path)
     path = path.substr(6);
-    console.log(path)
     const url = 'https://' + fetchUrl + '/wp-json/wp/v2/blogs?slug=' + path;
     const res = await fetch(url)
     const blog = await res.json()
-    //console.log(blog)
+    
     if (blog.length > 0){
     let date_posted = new Date(blog[0].date);
-
-    let raw_tags = blog[0].acf.tags === null ? [] : blog[0].acf.tags
-    let tags = [];
-    if (raw_tags.length > 0){
-      raw_tags.map((tag) =>{
-        tags.push[tag.name];
-      });
-    }
 
     const url2 = 'https://' + fetchUrl + '/wp-json/wp/v2/blogs?per_page=4';
     const res2 = await fetch(url2)
     const moreArticles = await res2.json()
-    //console.log(blog)
-    
-      
 
     return({
       currSlug: blog[0].slug,
       content: blog[0].content.rendered,
       short_description: blog[0].acf.short_description,
       title: blog[0].acf.title,
-      tags: tags,
-      author_name: blog[0].acf.author.display_name,
-      author_picture: blog[0].acf.author.user_avatar,
+      tags: blog[0].acf.tags,
+      authors: blog[0].acf.author,
       date_posted: date_posted,
-      author_job_title: blog[0].acf.author_job_title,
       fetching: false,
       moreArticles: moreArticles,
     })
@@ -106,7 +100,7 @@ class Post extends React.Component {
     
   }
 
-
+  
 
   render() {
     const { classes } = this.props;
@@ -119,8 +113,8 @@ class Post extends React.Component {
               <meta name="description" content={this.props.short_description} />
             </Head>
           <Grid container style={{marginBottom:'40px'}}>
-          <Grid xs={1} md={3} lg={4} xl={4}></Grid>
-          <Grid xs={10} md={6} lg={4} xl={4} >
+          <Grid item xs={1} md={3} lg={4} xl={4}></Grid>
+          <Grid item xs={10} md={6} lg={4} xl={4} >
           <div>
             <Typography variant="body1" style={{fontSize:'12px'}} paragraph>
               {this.formatDate(this.props.date_posted)}
@@ -129,16 +123,22 @@ class Post extends React.Component {
               {this.props.title}
             </Typography>
 
-            <Grid xs={12} style={{paddingBottom:'40px'}}>
+            <Grid item xs={12} style={{paddingBottom:'40px'}}>
               <Grid container>
-                <Grid xs={6} md={6} style={{display:'flex', alignItems:'center'}}>
-                <div className="author-profile" dangerouslySetInnerHTML={{__html: this.props.author_picture}}></div>
-                <div style={{display: 'inline-block', paddingLeft: '15px'}}>
-                <Typography variant="button">by {this.props.author_name}</Typography>
-                <Typography variant="caption">{this.props.author_job_title}</Typography>
-                </div>
+              {this.props.authors.map((author) => {
+                return(
+                <Grid item xs={6} md={6} style={{display:'flex', alignItems:'center'}}>
+                  <div className="author-profile"   dangerouslySetInnerHTML={{__html: author.user_avatar}}></div>
+                  <div style={{display: 'inline-block', paddingLeft: '15px'}}>
+                  <Typography variant="button">by {author.display_name}</Typography>
+                  <Typography variant="caption"><span dangerouslySetInnerHTML={{__html:author.user_description}}></span></Typography>
+                  </div>
                 </Grid>
+                )
+              
+              })}
               </Grid>
+                
             </Grid>
 
               <div className="content" dangerouslySetInnerHTML={{__html: this.props.content}}>
@@ -147,7 +147,7 @@ class Post extends React.Component {
             <div>
               {this.props.tags.map((tag ) => {
                 return(
-                  <Chip label={tag} className={classes.chip} />
+                  <Chip label={tag.name} className={classes.chip} />
                 )
               })}
 
@@ -172,7 +172,7 @@ class Post extends React.Component {
               
               {this.props.moreArticles.map((post) => {
                 if (post.slug != this.props.currSlug ){
-                  //console.log(post.slug)
+                  
                 return(
                   <Link key={post.id} href={{ pathname: 'post', query: { name: post.slug }}}  as={`/post?${post.slug}`} prefetch>
                   <Grid item xs={10} sm={8} md={4} lg={2} className="heroHover" style={{paddingBottom:'50px'}}>
@@ -194,7 +194,7 @@ class Post extends React.Component {
                         {this.formatDate(post.date)}
                       </Typography>
                       <Typography variant="caption" gutterBottom>
-                        By &nbsp; {post.acf.author.display_name}
+                        By &nbsp; {this.getAuthors(post.acf.author)}
                       </Typography>
                     </Paper>
                   </Grid>
@@ -204,7 +204,7 @@ class Post extends React.Component {
 
                     })}
 
-              <Grid xs={1} sm={2} md={4}></Grid>
+              <Grid item xs={1} sm={2} md={4}></Grid>
             </Grid>
           </Grid>
         </Grid>

--- a/pages/project.js
+++ b/pages/project.js
@@ -94,9 +94,9 @@ const styles = theme => ( {
 });
 
 class Project extends React.Component {
-  constructor(props) {
-    super(props);
-    this.props = {
+  constructor(children, router, href) {
+    super(children, router, href);
+    this.state = {
       /* initial state */
       
     };
@@ -104,7 +104,9 @@ class Project extends React.Component {
 
   //fetch details of the project here
   static async getInitialProps(nextProps){
-    let path = nextProps.query.name
+    let path = nextProps.asPath
+    path = path.substr(8);
+    console.log(path)
     const url = 'https://' + fetchUrl + '/wp-json/wp/v2/projects?slug=' + path;
     const res = await fetch(url)
     const project = await res.json()
@@ -114,8 +116,9 @@ class Project extends React.Component {
     const url2 = 'https://' + fetchUrl + '/wp-json/wp/v2/projects';
     const res2 = await fetch(url2)
     const moreProjects = await res2.json()
-    console.log(project)
+    //console.log(project)
     return{
+      currProject: project[0].slug,
       project: project[0].acf,
       fetching: false,
       bgColor: project[0].acf.project_theme_color,
@@ -197,10 +200,10 @@ class Project extends React.Component {
                 <Grid container>
                 <Grid item xs={10} md={6}>
                   <Typography variant="body1" style={{fontSize:'24px'}} gutterBottom paragraph>
-                    <div dangerouslySetInnerHTML={{__html: this.props.project.project_description}}></div>
+                    {this.props.project.project_description}
                   </Typography>
                   <Typography variant="button" paragraph>
-                    <a href="#" className="underline" style={{textDecoration: 'none', color:'black'}}>
+                    <a href={this.props.project.link} className="underline" style={{textDecoration: 'none', color:'black'}}>
                       Visit Site <Icon style={{fontSize:'14px', verticalAlign: 'middle'}}>chevron_right</Icon>
                     </a>
                   </Typography>
@@ -370,11 +373,11 @@ class Project extends React.Component {
 
                     <Grid container>
                     {this.props.moreProjects.map((project) => {
-                      if(project.slug != Router.query.name){
+                      if(project.slug != this.props.currProject){
                         return(
                           <Grid key={project.slug} item xs={4} md={4}>
-                            <a className="underline" style={{textDecoration: 'none', color: '#000000'}} href={'/project?name=' + project.slug}>
-                              <Typography variant="button">{this.props.project.client_name} | {this.props.project.project_title}</Typography>
+                            <a className="underline" style={{textDecoration: 'none', color: '#000000'}} href={'/project?' + project.slug}>
+                              <Typography variant="button">{project.acf.client_name} | {project.acf.project_title}</Typography>
                             </a>
                           </Grid>
                         )
@@ -395,8 +398,8 @@ class Project extends React.Component {
                 paddingBottom: '115px'
               }}>
                   <Typography variant="body1">
-                    Next Project    <a className="underline" style={{textDecoration: 'none', color: '#000000'}} href={'/project?name=' + this.props.project.next_project_link.post_name}>
-                      <b>{console.log(this.props.project.next_project_link.post_name)} <Icon style={{fontSize:'14px', verticalAlign: 'middle',}}>chevron_right</Icon></b>
+                    Next Project    <a className="underline" style={{textDecoration: 'none', color: '#000000'}} href={'/project?' + this.props.project.next_project_link.post_name}>
+                      <b>{this.props.project.next_project_link.post_title} <Icon style={{fontSize:'14px', verticalAlign: 'middle',}}>chevron_right</Icon></b>
                     </a>
                   </Typography>
               </Grid>

--- a/pages/work.js
+++ b/pages/work.js
@@ -187,32 +187,32 @@ class Work extends React.Component {
                 <Grid item xs={1} md={3}></Grid>
                 <Grid item xs={10} md={4} className={classes.contentCenter}>
 
-                <Link key={i} href={{ pathname: 'project', query: { name: project.slug }}}>
-                  <a style={{textDecoration: 'none', color:'black'}}>
-
-                      <div className={classes.projectLegend}>
+                <Link key={i} href={{ pathname: 'project', query: { name: project.slug }}} as={`/project?${project.slug}`}>
+                  
+                  <div>
+                      
                         <Typography variant="title" color="secondary" className={classes.projectLegend}>
                           Client &nbsp;
                         </Typography>
                         <Typography variant="title" color="primary" className={classes.projectLegend}>
                           {project.acf.client_name}
                         </Typography>
-                      </div>
-                      <div className={classes.subLegend}>
+                      
+                      
                         <Typography variant="display2" color="inherit">
                           {project.acf.project_title}
                         </Typography>
-                      </div>
+                      
                           <Button style={{paddingTop:'10px'}} disableRipple={true} className={"underline"}>
                             <Typography variant="button" color="inherit">
                               Learn more <Icon style={{fontSize:'14px', verticalAlign: 'middle',}}>chevron_right</Icon>
                             </Typography>
                           </Button>
-                    </a>
+                    </div>
                   </Link>
                 </Grid>
                   <Grid item xs={12} md={5} className={classes.contentCenter}>
-                    <Link key={i} href={{ pathname: 'project', query: { name: project.slug }}}>
+                    <Link key={i} href={{ pathname: 'project', query: { name: project.slug }}} as={`/project?${project.slug}`}>
                       <a className="projectLink">
                         <img
                           className="projectImg"


### PR DESCRIPTION
- Fetching Latest News - Custom data point in WordPress now
  - If news items are less than 3, blogs are displayed for that amount
- Next Project link fixes
- Links are now tailored for SEO purposes for **blogs & projects**
- Added data point for **visit site** in projects
- Multiple Author support added for blogs
  - Add new authors Users section
  - In blog, select any number of authors - as shown below
![image](https://user-images.githubusercontent.com/22185628/41185423-3cb57966-6b56-11e8-9eb6-da52e7e4aabb.png)

